### PR TITLE
tests on Rakefile

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,8 +1,9 @@
-require "rake"
+require 'rake'
+require 'rake/testtask'
 
 gemspec = eval(File.read(Dir["*.gemspec"].first))
 
-task :default => ["test:all"]
+task :default => ['test']
 
 desc "Validate the gemspec"
 task :gemspec do
@@ -34,11 +35,9 @@ task :syntax do
   end
 end
 
-namespace :test do
-  desc "Run all tests"
-  task :all do
-    Dir["test/**/*_test.rb"].each do |test_path|
-      system "ruby #{test_path}"
-    end
-  end
+Rake::TestTask.new do |t|
+  t.libs << "test"
+  t.test_files = FileList['test/*_test.rb']
+  t.verbose = true
 end
+

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -1,8 +1,9 @@
 require "codeclimate-test-reporter"
 CodeClimate::TestReporter.start
 
-$:.unshift File.expand_path('../../lib',  __FILE__)
 require "rubygems"
+require_relative '../lib/dummy'
+
 require "fileutils"
 require "test/unit"
 


### PR DESCRIPTION
changed way to load tests in the Rakefile.
usage of require_relative import.

this will break the build but the tests were already failing.
the way they were being run made the `rake` command to exit with status code 0 and wrongly give you the idea that they are good.
